### PR TITLE
BAU: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @govuk-one-login/auth-team @govuk-one-login/auth-leads @govuk-one-login/orchestration-leads @govuk-one-login/orchestration-team
+


### PR DESCRIPTION
## What 

Adding this file because it's been pointed out by the Orchestration Tech Lead that it is not included. For the time being I've used the same values as exist for authentication-frontend.