### PR TITLE
BAU: Change codeowners to digital-identity-frontend-capability

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @govuk-one-login/auth-team @govuk-one-login/auth-leads @govuk-one-login/orchestration-leads @govuk-one-login/orchestration-team
+* @govuk-one-login/digital-identity-frontend-capability
 


### PR DESCRIPTION
Following notes at https://govukverify.atlassian.net/wiki/spaces/LO/pages/4819812383, the spinner is now to be taken on by the Frontend Capability Team.

This removes auth and orchs codeownership of this repo and replaces it with the Frontend Capability Team