### PR TITLE
Pyic 8332 Flexible text for continue button.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/spinner",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Spinner component used when a user returns from IPV to authentication",
   "main": "index.js",
   "type": "module",

--- a/src/components/spinner.js
+++ b/src/components/spinner.js
@@ -98,6 +98,9 @@ export class Spinner {
         longWait: {
           spinnerStateText: element.dataset.longwaitSpinnerstatetext,
         },
+        continueButton: {
+          text: element.dataset.continuebuttonText ?? "Continue"
+        }
       };
 
       this.config = {
@@ -145,7 +148,7 @@ export class Spinner {
       },
       {
         nodeName: "button",
-        text: "Continue",
+        text: this.content.continueButton.text,
         buttonDisabled: this.state.buttonDisabled,
         classes: ["govuk-button", "govuk-!-margin-top-4"],
       },

--- a/src/components/spinner.test.js
+++ b/src/components/spinner.test.js
@@ -387,4 +387,72 @@ describe("the spinner component", () => {
       expect(spinner.domRequirementsMet).toBe(false);
     });
   });
+
+      describe("the spinner component with custom continue text", () => {
+        document.body.innerHTML = `
+        <div id="spinner-container"
+         data-initial-heading="Initial heading text"
+         data-initial-spinnerStateText="Initial spinner state text"
+         data-initial-spinnerState="pending"
+         data-error-heading="Error heading"
+         data-error-messageText="Error message text"
+         data-error-whatYouCanDo-heading="Error what you can do heading"
+         data-error-whatYouCanDo-message-text1="Error what you can do message text1"
+         data-error-whatYouCanDo-message-link-href="Error what you can do message link href"
+         data-error-whatYouCanDo-message-link-text="Error what you can do message link text"
+         data-error-whatYouCanDo-message-text2="Error what you can do message link text2"
+         data-complete-spinnerState="Spinner state complete"
+         data-longWait-spinnerStateText="Long wait spinner text"
+         data-ms-before-informing-of-long-wait="6000"
+         data-ms-before-abort="30000"
+         data-continueButton-text="Custom continue text">
+        <form action="/ipv-callback" method="post" novalidate="novalidate">
+            <input type="hidden" name="_csrf" value="csrfToken" />
+            <div class="govuk-form-group">
+                <h1 class="govuk-label-wrapper">
+                    <label class="govuk-label govuk-label--l" for="more-detail">
+                        Label text
+                    </label>
+                </h1>
+                <p class="govuk-body">Paragraph</p>
+                <button type="submit" class="govuk-button">
+                    Button text
+                </button>
+            </div>
+        </form>
+    </div>`;
+        const container = document.getElementById("spinner-container");
+        const spinner = new Spinner(container);
+
+        test("should include all properties from data attributes", () => {
+            const expectedContent = {
+                complete: {spinnerState: "Spinner state complete"},
+                error: {
+                    heading: "Error heading",
+                    messageText: "Error message text",
+                    whatYouCanDo: {
+                        heading: "Error what you can do heading",
+                        message: {
+                            link: {
+                                href: "Error what you can do message link href",
+                                text: "Error what you can do message link text",
+                            },
+                            text1: "Error what you can do message text1",
+                            text2: "Error what you can do message link text2",
+                        },
+                    },
+                },
+                initial: {
+                    heading: "Initial heading text",
+                    spinnerState: "pending",
+                    spinnerStateText: "Initial spinner state text",
+                },
+                longWait: {spinnerStateText: "Long wait spinner text"},
+                continueButton: {
+                    text: "Custom continue text"
+                }
+            };
+            expect(spinner.content).toEqual(expectedContent);
+        });
+    });
 });


### PR DESCRIPTION
Text content of ''continue button'' is hard coded to english version and currently can not be changed.
I added additional parameter to allow customisation of that text with backward compatibility.

Related Jira ticket
[PYIC-8332](https://govukverify.atlassian.net/browse/PYIC-8332)

[PYIC-8332]: https://govukverify.atlassian.net/browse/PYIC-8332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

![Screenshot 2025-05-15 at 15 54 07](https://github.com/user-attachments/assets/370df3ad-c10f-4d5d-9da6-5e964f3cddb5)
