### PR TITLE
Pyic 8471 Add timestamp stored in sessionStorage and initTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If any required attribute is missing, the component will set `domRequirementsMet
 
 ### 3. Initialising timer
 
-The Spinner component uses either an existing or newly generated timestamp as `initTime`, storing it in `sessionStorage` as `spinnerInitTime`. During the `initialiseState` call in the constructor, it checks if `spinnerInitTime` is already there. If yes, it reuses it. If not, it creates a new one, stores it, and applies it to the config. This way, the spinner stays consistent across page refreshes, and also handles sleep or power saving mode on mobile without breaking.
+The Spinner component uses either an existing or newly generated timestamp as `initTime`, storing it in `sessionStorage` as `spinnerInitTime`. During the `initTimer` function call in the `init`, it checks if `spinnerInitTime` is already there. If yes, it reuses it. If not, it creates a new one, stores it, and applies it to the config. This way, the spinner stays consistent across page refreshes, and also handles sleep or power saving mode on mobile without breaking.
 
 Attribute `data-ms-between-requests` specify how often in ms polling request is executed.
 
@@ -121,9 +121,10 @@ At the end of each recursive call `updateDom` is called to apply changes in the 
 
 - Changed behaviour of the spinner component to relay on the polling mechanism and timestamp stored in the session storage.
   - Added `initTime` to the config and stores it in session storage 
+  - Added abortController to cancel request on page unload
   - `updateDom` function is executed at the end of every `requestIDProcessingStatus` call
   - Removed `msBetweenDomUpdate`
-  - Removed timers as spinner relay on time elapsed from `initTime` checked every `requestIDProcessingStatus` call
+  - Removed timers as spinner relay on time elapsed from `initTime` 
 
 ### 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -90,14 +90,15 @@ Where this element is found, it is passed as an argument to the `Spinner` constr
 
 If any required attribute is missing, the component will set `domRequirementsMet` to `false`, preventing state from being initialised. As before, if this requirement is not met, nothing happens and the user can proceed to use the non-JavaScript version.
 
-### 3. Initialising timer
+### 3. Initialising timers
 
 The Spinner component uses either an existing or newly generated timestamp as `initTime`, storing it in `sessionStorage` as `spinnerInitTime`. During the `initTimer` function call in the `init`, it checks if `spinnerInitTime` is already there. If yes, it reuses it. If not, it creates a new one, stores it, and applies it to the config. This way, the spinner stays consistent across page refreshes, and also handles sleep or power saving mode on mobile without breaking.
 
-Attribute `data-ms-between-requests` specify how often in ms polling request is executed.
+The `updateDomTimer` timer will update the DOM at set intervals to reflect any changes in the virtual DOM.
+The duration of this timer is set within the Spinner `config` property.
+
 
 If time elapsed from `initTime` is larger than `msBeforeAbort` or `msBeforeInformingOfLongWait` it update the state of the spinner to reflect actual state.
-
 
 ### 4. Perform initial update
 
@@ -111,20 +112,16 @@ If a `COMPLETED` or `INTERVENTION` status is returned by the API, the component 
 
 If a status of `ERROR` is returned, the component is updated spinner state to reflect an error and further `fetch` requests are prevented. Also, `initTime` is removed from session storage.
 
-If no `fetch` request has resulted in a status of `COMPLETED`, `INTERVENTION` or `ERROR`, it check how much time elapsed from the `initTime`. If elapsed time is longer than `msBeforeAbort` - recursive call is prevent from further execution and updates the spinner state. Also, `initTime` is removed from session storage. If time elapsed is longer than `msBeforeInformingOfLongWait` but shorter than `msBeforeAbort`, spinner state is updated to reflect the changes in next dom update.
-
-At the end of each recursive call `updateDom` is called to apply changes in the dom according to the spinner state. 
+If no `fetch` request has resulted in a status of `COMPLETED`, `INTERVENTION` or `ERROR`, it schedule next request as set in in `config`. Once executed it checks how much time elapsed from the `initTime`. If elapsed time is longer than `msBeforeAbort`, recursive call is prevent from further execution and updates the spinner state to reflect error. Also, `initTime` is removed from session storage.
 
 ## Version History
 
 ### 2.1.0
 
-- Changed behaviour of the spinner component to relay on the polling mechanism and timestamp stored in the session storage.
+- Introduced initialisation time stored in sessionStorage to make spinner more accurate and bug resistant.
   - Added `initTime` to the config and stores it in session storage 
   - Added abortController to cancel request on page unload
-  - `updateDom` function is executed at the end of every `requestIDProcessingStatus` call
-  - Removed `msBetweenDomUpdate`
-  - Removed timers as spinner relay on time elapsed from `initTime` 
+  - Removed `informUserWhereWaitIsLong`  and `abortUnresponsiveRequest` as those are checked each dom update according to time elapsed from `initTime`
 
 ### 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ Initialisation then proceeds to do an initial update of the DOM, replacing the s
 
 Initialisation then proceeds to request the ID processing status. This uses recursive calls to `this.requestIDProcessingStatus()` at set intervals (as set in `config`), each of which initiates a `fetch` request for the processing status.
 
-If a `COMPLETED` or `INTERVENTION` status is returned by the API, the component will be updated the spinner state to reflect completion, the call to action will be enabled and further `fetch` requests will be prevented. Also, `initTime` is removed from session storage. Clicking the enabled call to action will result in the user making a synchronous `POST` request to the same route and server-side processing will determine if they can continue to the RP or be presented with a page reflecting an account intervention being in place.
+If a `COMPLETED` or `INTERVENTION` status is returned by the API, the component will update the spinner state to reflect completion, the call to action will be enabled and further `fetch` requests will be prevented. Also, `initTime` is removed from session storage. Clicking the enabled call to action will result in the user making a synchronous `POST` request to the same route and server-side processing will determine if they can continue to the RP or be presented with a page reflecting an account intervention being in place.
 
-If a status of `ERROR` is returned, the component is updated spinner state to reflect an error and further `fetch` requests are prevented. Also, `initTime` is removed from session storage.
+If a status of `ERROR` is returned, the component updates its spinner state to reflect an error and further `fetch` requests are prevented. Also, `initTime` is removed from session storage.
 
-If no `fetch` request has resulted in a status of `COMPLETED`, `INTERVENTION` or `ERROR`, it schedule next request as set in in `config`. Once executed it checks how much time elapsed from the `initTime`. If elapsed time is longer than `msBeforeAbort`, recursive call is prevent from further execution and updates the spinner state to reflect error. Also, `initTime` is removed from session storage.
+If a `fetch` request doesn't result in a status of `COMPLETED`, `INTERVENTION` or `ERROR`, the component will schedule another request after the period set in `config`. Once the time period has elapsed the component checks how much time has elapsed from the `initTime`. If the elapsed time is longer than `msBeforeAbort` the recursive call is not made, the spinner state is updated to reflect error, and `initTime` is removed from session storage.
 
 ## Version History
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/spinner",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Spinner component used when a user returns from IPV to authentication",
   "main": "index.js",
   "type": "module",

--- a/src/components/__snapshots__/spinner.test.js.snap
+++ b/src/components/__snapshots__/spinner.test.js.snap
@@ -19,7 +19,7 @@ exports[`the spinner component when instantiated with a badly formed HTMLDivElem
       "
 `;
 
-exports[`the spinner component when instantiated with a correctly formed HTMLDivElement should set up the spinner HTML correctly 1`] = `"<div><h1 class="govuk-heading-l">Initial heading text</h1><div id="spinner" class="spinner spinner__pending centre pending"></div><p class="centre spinner-state-text govuk-body">Initial spinner state text</p><button class="govuk-button govuk-!-margin-top-4" disabled="true">Continue</button></div><div aria-live="assertive" class="govuk-visually-hidden"></div>"`;
+exports[`the spinner component when instantiated with a correctly formed HTMLDivElement should set up the spinner HTML correctly with initial values 1`] = `"<div><h1 class="govuk-heading-l">Initial heading text</h1><div id="spinner" class="spinner spinner__pending centre pending"></div><p class="centre spinner-state-text govuk-body">Initial spinner state text</p><button class="govuk-button govuk-!-margin-top-4" disabled="true">Continue</button></div><div aria-live="assertive" class="govuk-visually-hidden"></div>"`;
 
 exports[`the spinner component when the API call returns COMPLETED should update contents correctly 1`] = `"<div><h1 class="govuk-heading-l">Initial heading text</h1><div id="spinner" class="spinner spinner__pending centre spinner__ready"></div><p class="centre spinner-state-text govuk-body">Spinner state complete</p><button class="govuk-button govuk-!-margin-top-4">Continue</button></div><div aria-live="assertive" class="govuk-visually-hidden">Button enabled</div>"`;
 

--- a/src/components/spinner.js
+++ b/src/components/spinner.js
@@ -265,8 +265,6 @@ export class Spinner {
           } else if (this.notInErrorOrDoneState()) {
             setTimeout(async () => {
               if ((Date.now() - this.initTime) >= this.config.msBeforeAbort) {
-                this.reflectError();
-                this.updateDom();
                 return;
               }
               await this.requestIDProcessingStatus();

--- a/src/components/spinner.js
+++ b/src/components/spinner.js
@@ -64,16 +64,6 @@ export class Spinner {
         error: false,
         virtualDom: [],
       };
-
-      let spinnerInitTime = sessionStorage.getItem('spinnerInitTime')
-      if(spinnerInitTime === null) {
-        spinnerInitTime = Date.now();
-        sessionStorage.setItem('spinnerInitTime', spinnerInitTime.toString());
-      } else {
-        spinnerInitTime = parseInt(spinnerInitTime, 10);
-      }
-      this.initTime = spinnerInitTime;
-      this.updateAccordingToTimeElapsed();
     }
   }
 
@@ -294,8 +284,21 @@ export class Spinner {
     );
   };
 
+  initTimer = () => {
+    let spinnerInitTime = sessionStorage.getItem('spinnerInitTime')
+    if(spinnerInitTime === null) {
+      spinnerInitTime = Date.now();
+      sessionStorage.setItem('spinnerInitTime', spinnerInitTime.toString());
+    } else {
+      spinnerInitTime = parseInt(spinnerInitTime, 10);
+    }
+    this.initTime = spinnerInitTime;
+    this.updateAccordingToTimeElapsed();
+  }
+
   init() {
     if (this.domRequirementsMet) {
+      this.initTimer();
       this.initialiseContainers();
       this.updateDom();
       this.requestIDProcessingStatus();

--- a/src/components/spinner.js
+++ b/src/components/spinner.js
@@ -24,6 +24,7 @@ export class Spinner {
     this.state.ariaButtonEnabledMessage =
       this.content.complete.ariaButtonEnabledMessage;
     this.state.done = true;
+    sessionStorage.removeItem('spinnerInitTime');
   };
 
   reflectError = () => {
@@ -32,6 +33,7 @@ export class Spinner {
     this.state.spinnerState = "spinner__failed";
     this.state.done = true;
     this.state.error = true;
+    sessionStorage.removeItem('spinnerInitTime');
   };
 
   reflectLongWait() {
@@ -63,20 +65,15 @@ export class Spinner {
         virtualDom: [],
       };
 
-      const navType = performance.getEntriesByType('navigation')[0]?.type;
-      if(navType === 'navigate') {
-        sessionStorage.removeItem('spinnerInitTime');
-      }
-
       let spinnerInitTime = sessionStorage.getItem('spinnerInitTime')
       if(spinnerInitTime === null) {
         spinnerInitTime = Date.now();
         sessionStorage.setItem('spinnerInitTime', spinnerInitTime.toString());
       } else {
         spinnerInitTime = parseInt(spinnerInitTime, 10);
-        this.updateAccordingToTimeElapsed();
       }
       this.initTime = spinnerInitTime;
+      this.updateAccordingToTimeElapsed();
     }
   }
 

--- a/src/components/spinner.js
+++ b/src/components/spinner.js
@@ -73,6 +73,7 @@ export class Spinner {
         error: false,
         virtualDom: [],
       };
+      this.timers = {};
 
       let spinnerInitTime = sessionStorage.getItem('spinnerInitTime')
       if(spinnerInitTime === null) {

--- a/src/components/spinner.js
+++ b/src/components/spinner.js
@@ -262,6 +262,10 @@ export class Spinner {
       } else if (this.notInErrorOrDoneState()) {
         this.updateAccordingToTimeElapsed();
         setTimeout(async () => {
+          if ((Date.now() - this.initTime) >= this.config.msBeforeAbort) {
+            this.reflectError();
+            return;
+          }
           await this.requestIDProcessingStatus();
         }, this.config.msBetweenRequests);
       }

--- a/src/components/spinner.js
+++ b/src/components/spinner.js
@@ -24,7 +24,6 @@ export class Spinner {
     this.state.ariaButtonEnabledMessage =
       this.content.complete.ariaButtonEnabledMessage;
     this.state.done = true;
-    sessionStorage.removeItem('spinnerInitTime');
   };
 
   reflectError = () => {
@@ -33,7 +32,6 @@ export class Spinner {
     this.state.spinnerState = "spinner__failed";
     this.state.done = true;
     this.state.error = true;
-    sessionStorage.removeItem('spinnerInitTime');
   };
 
   reflectLongWait() {
@@ -65,12 +63,18 @@ export class Spinner {
         virtualDom: [],
       };
 
+      const navType = performance.getEntriesByType('navigation')[0]?.type;
+      if(navType === 'navigate') {
+        sessionStorage.removeItem('spinnerInitTime');
+      }
+
       let spinnerInitTime = sessionStorage.getItem('spinnerInitTime')
       if(spinnerInitTime === null) {
         spinnerInitTime = Date.now();
         sessionStorage.setItem('spinnerInitTime', spinnerInitTime.toString());
       } else {
         spinnerInitTime = parseInt(spinnerInitTime, 10);
+        this.updateAccordingToTimeElapsed();
       }
       this.initTime = spinnerInitTime;
     }
@@ -264,6 +268,7 @@ export class Spinner {
         setTimeout(async () => {
           if ((Date.now() - this.initTime) >= this.config.msBeforeAbort) {
             this.reflectError();
+            this.updateDom();
             return;
           }
           await this.requestIDProcessingStatus();

--- a/src/components/spinner.js
+++ b/src/components/spinner.js
@@ -254,13 +254,13 @@ export class Spinner {
             this.reflectError();
           } else if (this.notInErrorOrDoneState()) {
             this.updateAccordingToTimeElapsed();
-            setTimeout(() => {
+            setTimeout(async () => {
               if ((Date.now() - this.initTime) >= this.config.msBeforeAbort) {
                 this.reflectError();
                 this.updateDom();
                 return;
               }
-              this.requestIDProcessingStatus();
+              await this.requestIDProcessingStatus();
             }, this.config.msBetweenRequests);
           }
         })

--- a/src/components/spinner.js
+++ b/src/components/spinner.js
@@ -277,7 +277,10 @@ export class Spinner {
             console.error("Error in requestIDProcessingStatus:", e);
             this.reflectError();
           }
-        });
+        })
+        .finally(() => {
+          this.updateDom();
+        })
   }
 
   // For the Aria alert to work reliably we need to create its container once and then update the contents
@@ -329,8 +332,7 @@ export class Spinner {
       this.initTimer();
       this.initialiseContainers();
       this.updateDom();
-      this.requestIDProcessingStatus()
-          .then(() => this.updateDom());
+      this.requestIDProcessingStatus();
     }
   }
 

--- a/src/components/spinner.js
+++ b/src/components/spinner.js
@@ -266,6 +266,7 @@ export class Spinner {
             setTimeout(async () => {
               if ((Date.now() - this.initTime) >= this.config.msBeforeAbort) {
                 this.reflectError();
+                this.updateDom();
                 return;
               }
               await this.requestIDProcessingStatus();

--- a/src/components/spinner.test.js
+++ b/src/components/spinner.test.js
@@ -53,7 +53,6 @@ describe("the spinner component", () => {
   describe("config property", () => {
     test("should exist with default values", () => {
       expect(spinner).toHaveProperty("config");
-      expect(spinner.config.msBetweenDomUpdate).toEqual(2000);
     });
     test("should be configurable through the dataset", () => {
       expect(spinner.config.msBeforeAbort).toEqual(30000);
@@ -344,17 +343,27 @@ describe("the spinner component", () => {
       expect(spinner.domRequirementsMet).toBe(true);
     });
 
-    test("should have a timers property", () => {
-      expect(spinner).toHaveProperty("timers");
-    });
-
     test("should have a createVirtualDom property", () => {
       expect(spinner).toHaveProperty("createVirtualDom");
     });
 
-    test("should set up the spinner HTML correctly", () => {
-      spinner.init();
-      expect(container.innerHTML).toMatchSnapshot();
+    describe("should set up the spinner HTML correctly", () => {
+      beforeEach(() => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+              json: () => Promise.resolve({ status: "PROCESSING" }),
+            }),
+        );
+      });
+
+      afterEach(() => {
+        jest.restoreAllMocks();
+      });
+
+      test("with initial values", () => {
+        spinner.init();
+        expect(container.innerHTML).toMatchSnapshot();
+      });
     });
   });
 
@@ -537,6 +546,7 @@ describe("the spinner component", () => {
     beforeEach(() => {
       document.body.innerHTML = getValidSpinnerDivHtml({
         msBeforeInformingOfLongWait: 20,
+        msBetweenRequests: 5,
         msBetweenDomUpdate: 10,
       });
       container = document.getElementById("spinner-container");
@@ -555,9 +565,7 @@ describe("the spinner component", () => {
 
     test("should update contents correctly", async () => {
       spinner.init();
-
-      await wait(50);
-
+      await wait(30)
       expect(container.innerHTML).toMatchSnapshot();
     });
   });

--- a/src/components/spinner.test.js
+++ b/src/components/spinner.test.js
@@ -605,7 +605,7 @@ describe("the spinner component", () => {
     beforeEach(() => {
       document.body.innerHTML = getValidSpinnerDivHtml({
         msBeforeAbort: 15,
-        msBetweenRequests: 20,
+        msBetweenRequests: 5,
         msBetweenDomUpdate: 10,
       });
       container = document.getElementById("spinner-container");

--- a/src/components/spinner.test.js
+++ b/src/components/spinner.test.js
@@ -625,7 +625,7 @@ describe("the spinner component", () => {
     test("should stop polling", async () => {
       const spyRequestIDProcessingStatus = jest.spyOn(spinner, 'requestIDProcessingStatus');
       spinner.init();
-      await wait(30)
+      await wait(50)
       expect(spyRequestIDProcessingStatus).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/components/spinner.test.js
+++ b/src/components/spinner.test.js
@@ -622,7 +622,7 @@ describe("the spinner component", () => {
       jest.restoreAllMocks();
     });
 
-    test("should stop polling and call recursive function twice", async () => {
+    test("should stop polling", async () => {
       const spyRequestIDProcessingStatus = jest.spyOn(spinner, 'requestIDProcessingStatus');
       spinner.init();
       await wait(30)

--- a/src/components/spinner.test.js
+++ b/src/components/spinner.test.js
@@ -48,6 +48,10 @@ beforeEach(() => {
   spinner = new Spinner(container);
 });
 
+beforeAll(() => {
+  global.performance.getEntriesByType = jest.fn(() => [{ type: 'navigate' }]);
+});
+
 describe("the spinner component", () => {
   describe("config property", () => {
     test("should exist with default values", () => {
@@ -572,6 +576,7 @@ describe("the spinner component", () => {
     beforeEach(() => {
       document.body.innerHTML = getValidSpinnerDivHtml({
         msBeforeAbort: 20,
+        msBetweenRequests: 10,
       });
       container = document.getElementById("spinner-container");
       spinner = new Spinner(container);
@@ -588,7 +593,7 @@ describe("the spinner component", () => {
     });
 
     test("should update contents correctly", async () => {
-      spinner.init();
+      await spinner.init();
 
       await wait(50);
 
@@ -635,7 +640,6 @@ describe("the spinner component", () => {
             json: () => Promise.resolve({ status: "PROCESSING" }),
           }),
       );
-      sessionStorage.clear();
     });
 
     afterEach(() => {
@@ -644,11 +648,13 @@ describe("the spinner component", () => {
     });
 
 
-    test("should save init time in session storage", () => {
-      spinner.init();
+    test("should save init time in session storage", async () => {
+      await spinner.init();
       const initTime = sessionStorage.getItem("spinnerInitTime");
-      expect(initTime).toBeDefined();
+      expect(initTime).not.toBeNull();
     });
+
+
   });
 
   describe("when spinner is end in completion state", () => {
@@ -664,7 +670,6 @@ describe("the spinner component", () => {
             json: () => Promise.resolve({ status: "COMPLETED" }),
           }),
       );
-      sessionStorage.clear();
     });
 
     afterEach(() => {
@@ -672,13 +677,13 @@ describe("the spinner component", () => {
     });
 
 
-    test("should clear init time from session storage", async () => {
-      spinner.init();
+    test("should not clear init time from session storage", async () => {
+      await spinner.init();
       const initTime = sessionStorage.getItem("spinnerInitTime");
-      expect(initTime).toBeDefined();
+      expect(initTime).not.toBeNull();
       await wait(20);
-      expect(spinner.state.spinnerState === "Spinner state complete")
-      expect(sessionStorage.getItem("spinnerInitTime")).toBeNull();
+      expect(spinner.state.spinnerState).toBe("spinner__ready")
+      expect(sessionStorage.getItem("spinnerInitTime")).not.toBeNull();
     });
   });
 
@@ -693,24 +698,22 @@ describe("the spinner component", () => {
 
       global.fetch = jest.fn(() =>
           Promise.resolve({
-            json: () => Promise.resolve({ status: "COMPLETED" }),
+            json: () => Promise.resolve({ status: "PROCESSING" }),
           }),
       );
-      sessionStorage.clear();
     });
 
     afterEach(() => {
       jest.restoreAllMocks();
     });
 
-
-    test("should clear init time from session storage", async () => {
-      spinner.init();
+    test("should not clear init time from session storage", async () => {
+      await spinner.init();
       const initTime = sessionStorage.getItem("spinnerInitTime");
-      expect(initTime).toBeDefined();
+      expect(initTime).not.toBeNull();
       await wait(30);
-      expect(spinner.state.spinnerState === "spinner__failed")
-      expect(sessionStorage.getItem("spinnerInitTime")).toBeNull();
+      expect(spinner.state.spinnerState).toBe("spinner__failed");
+      expect(sessionStorage.getItem("spinnerInitTime")).not.toBeNull();
     });
   });
 

--- a/src/components/spinner.test.js
+++ b/src/components/spinner.test.js
@@ -19,6 +19,7 @@ function getValidSpinnerDivHtml(params = {}) {
          data-longWait-spinnerStateText="Long wait spinner text"
          data-ms-before-informing-of-long-wait="${params.msBeforeInformingOfLongWait || 6000}"
          data-ms-before-abort="${params.msBeforeAbort || 30000}"
+         data-ms-between-dom-update="${params.msBetweenDomUpdate || 2000}"
          data-ms-between-requests="${params.msBetweenRequests || 5000}">
         <form action="/ipv-callback" method="post" novalidate="novalidate">
             <input type="hidden" name="_csrf" value="csrfToken" />
@@ -546,7 +547,8 @@ describe("the spinner component", () => {
     beforeEach(() => {
       document.body.innerHTML = getValidSpinnerDivHtml({
         msBeforeInformingOfLongWait: 20,
-        msBetweenRequests: 5,
+        msBetweenRequests: 10,
+        msBetweenDomUpdate: 10,
       });
       container = document.getElementById("spinner-container");
       spinner = new Spinner(container);
@@ -574,6 +576,7 @@ describe("the spinner component", () => {
       document.body.innerHTML = getValidSpinnerDivHtml({
         msBeforeAbort: 20,
         msBetweenRequests: 10,
+        msBetweenDomUpdate: 10,
       });
       container = document.getElementById("spinner-container");
       spinner = new Spinner(container);
@@ -603,6 +606,7 @@ describe("the spinner component", () => {
       document.body.innerHTML = getValidSpinnerDivHtml({
         msBeforeAbort: 15,
         msBetweenRequests: 20,
+        msBetweenDomUpdate: 10,
       });
       container = document.getElementById("spinner-container");
       spinner = new Spinner(container);
@@ -658,6 +662,7 @@ describe("the spinner component", () => {
     beforeEach(() => {
       document.body.innerHTML = getValidSpinnerDivHtml({
         msBetweenRequests: 10,
+        msBetweenDomUpdate: 10,
       });
       container = document.getElementById("spinner-container");
       spinner = new Spinner(container);

--- a/src/components/spinner.test.js
+++ b/src/components/spinner.test.js
@@ -601,12 +601,12 @@ describe("the spinner component", () => {
     });
   });
 
-  describe("when polling end in processing before abort time and when setTimeout is called is after abort time", () => {
+  describe("when scheduled setTimeout tries to execute recursive function after msBeforeAbort", () => {
     beforeEach(() => {
       document.body.innerHTML = getValidSpinnerDivHtml({
         msBeforeAbort: 15,
         msBetweenRequests: 5,
-        msBetweenDomUpdate: 10,
+        msBetweenDomUpdate: 2000,
       });
       container = document.getElementById("spinner-container");
       spinner = new Spinner(container);
@@ -694,6 +694,7 @@ describe("the spinner component", () => {
       document.body.innerHTML = getValidSpinnerDivHtml({
         msBeforeAbort: 20,
         msBetweenRequests: 10,
+        msBetweenDomUpdate: 5,
       });
       container = document.getElementById("spinner-container");
       spinner = new Spinner(container);

--- a/src/components/spinner.test.js
+++ b/src/components/spinner.test.js
@@ -48,9 +48,6 @@ beforeEach(() => {
   spinner = new Spinner(container);
 });
 
-beforeAll(() => {
-  global.performance.getEntriesByType = jest.fn(() => [{ type: 'navigate' }]);
-});
 
 describe("the spinner component", () => {
   describe("config property", () => {
@@ -677,13 +674,13 @@ describe("the spinner component", () => {
     });
 
 
-    test("should not clear init time from session storage", async () => {
+    test("should clear init time from session storage", async () => {
       await spinner.init();
       const initTime = sessionStorage.getItem("spinnerInitTime");
       expect(initTime).not.toBeNull();
       await wait(20);
       expect(spinner.state.spinnerState).toBe("spinner__ready")
-      expect(sessionStorage.getItem("spinnerInitTime")).not.toBeNull();
+      expect(sessionStorage.getItem("spinnerInitTime")).toBeNull();
     });
   });
 
@@ -707,13 +704,13 @@ describe("the spinner component", () => {
       jest.restoreAllMocks();
     });
 
-    test("should not clear init time from session storage", async () => {
+    test("should clear init time from session storage", async () => {
       await spinner.init();
       const initTime = sessionStorage.getItem("spinnerInitTime");
       expect(initTime).not.toBeNull();
       await wait(30);
       expect(spinner.state.spinnerState).toBe("spinner__failed");
-      expect(sessionStorage.getItem("spinnerInitTime")).not.toBeNull();
+      expect(sessionStorage.getItem("spinnerInitTime")).toBeNull();
     });
   });
 

--- a/src/components/spinner.test.js
+++ b/src/components/spinner.test.js
@@ -622,7 +622,7 @@ describe("the spinner component", () => {
       jest.restoreAllMocks();
     });
 
-    test("should end in error state due to the abort time", async () => {
+    test("should stop polling and call recursive function twice", async () => {
       const spyRequestIDProcessingStatus = jest.spyOn(spinner, 'requestIDProcessingStatus');
       spinner.init();
       await wait(30)

--- a/src/components/spinner.test.js
+++ b/src/components/spinner.test.js
@@ -606,7 +606,7 @@ describe("the spinner component", () => {
       document.body.innerHTML = getValidSpinnerDivHtml({
         msBeforeAbort: 15,
         msBetweenRequests: 5,
-        msBetweenDomUpdate: 2000,
+        msBetweenDomUpdate: 25,
       });
       container = document.getElementById("spinner-container");
       spinner = new Spinner(container);
@@ -625,9 +625,9 @@ describe("the spinner component", () => {
     test("should end in error state due to the abort time", async () => {
       spinner.init();
       await wait(10)
-      expect(spinner.state.spinnerState === "pending")
-      await wait(15)
-      expect(spinner.state.spinnerState === "spinner__failed")
+      expect(spinner.state.spinnerState).toBe("pending");
+      await wait(20)
+      expect(spinner.state.spinnerState).toBe("spinner__failed");
     });
   });
 

--- a/src/components/spinner.test.js
+++ b/src/components/spinner.test.js
@@ -605,8 +605,8 @@ describe("the spinner component", () => {
     beforeEach(() => {
       document.body.innerHTML = getValidSpinnerDivHtml({
         msBeforeAbort: 15,
-        msBetweenRequests: 5,
-        msBetweenDomUpdate: 25,
+        msBetweenRequests: 10,
+        msBetweenDomUpdate: 2000,
       });
       container = document.getElementById("spinner-container");
       spinner = new Spinner(container);
@@ -623,11 +623,10 @@ describe("the spinner component", () => {
     });
 
     test("should end in error state due to the abort time", async () => {
+      const spyRequestIDProcessingStatus = jest.spyOn(spinner, 'requestIDProcessingStatus');
       spinner.init();
-      await wait(10)
-      expect(spinner.state.spinnerState).toBe("pending");
-      await wait(20)
-      expect(spinner.state.spinnerState).toBe("spinner__failed");
+      await wait(30)
+      expect(spyRequestIDProcessingStatus).toHaveBeenCalledTimes(2);
     });
   });
 


### PR DESCRIPTION
## Proposed changes
### What changed

- Spinner component 
    - Removed timers
    - Introduced initTime stored in sessionStorage 
    - Added abortController to handle fetch error during page reload
    - Updated readme.md

### Why did it change

"During the v2 app switch-ons in prod it’s been noticed that in some cases the MAM/DAD spinner polling for DCMAW VC receipt appears not to timeout within the configured window and/or stops but then resumes some time later. Because the EVCS access token has an expiry of 1 hour, eventually the polling calls to EVCS fail with 401s.

It’s possible that this is being caused by browser throttling (background tab, device sleep, power saving) because of users leaving the tab open running and abandoning their journeys."

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8471](https://govukverify.atlassian.net/browse/PYIC-8471)

### Checklist
- [x] READMEs and documentation up-to-date
- [x] Browser/ unit/ Selenium tests have been written/ updated



  
 

[PYIC-8471]: https://govukverify.atlassian.net/browse/PYIC-8471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ